### PR TITLE
feat(config): Allow for setting a run field to call a command to run

### DIFF
--- a/examples/python/1_matplotlib.py
+++ b/examples/python/1_matplotlib.py
@@ -1,0 +1,11 @@
+# Use the run script to run these examples, along with the default
+# Configuration!
+x = [1, 2, 3, 4]
+y = [1, 3, 2, 4]
+
+plt.plot(x, y)
+plt.xlabel("X-axis")
+plt.ylabel("Y-axis")
+plt.title("QuickerMD's Awesome Plot")
+
+plt.show()

--- a/examples/run.ps1
+++ b/examples/run.ps1
@@ -1,0 +1,12 @@
+param(
+    [Parameter(Mandatory)]
+    [string]$path
+)
+
+$extension = [System.IO.Path]::GetExtension($path).SubString(1)
+
+if ($extension -like "py") {
+    $extension = "python"
+}
+
+cat $path | quicker_md --lang $extension --show-input

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -68,11 +68,11 @@ impl<'lang> QuickMDOutput {
             return Ok(QuickMDOutput {
                 output_file: PathBuf::from(out_file),
                 stdout,
-                stderr
+                stderr,
             });
         }
 
-        let ret = QuickMDOutput::run(PathBuf::from(out_file.clone()));
+        let ret = QuickMDOutput::run(PathBuf::from(out_file.clone()), template);
 
         drop(out_file);
         _ = tmp_dir.close(); // Supress error
@@ -114,9 +114,16 @@ impl<'lang> QuickMDOutput {
         })
     }
 
-    pub fn run(file: PathBuf) -> std::io::Result<Self> {
+    pub fn run(file: PathBuf, template: &'lang Template) -> std::io::Result<Self> {
         let output_file = format!("{}", file.to_str().unwrap());
-        let output = Command::new(output_file).output()?;
+        let output;
+
+        // TODO: Allow for variables
+        if let Some(exe_command) = template.get_run_command() {
+            output = Command::new(exe_command).output()?;
+        } else {
+            output = Command::new(output_file).output()?;
+        }
 
         let stdout = u8_to_str_vec(output.stdout);
         let stderr = u8_to_str_vec(output.stderr);

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub struct LanguageConfig {
     prefix: Option<String>,
     extension: Option<String>,
 
-    run_command: Option<String>,
+    run_command: Option<RunCommandType>,
 
     #[serde(default)]
     redir_input: bool,
@@ -32,6 +32,13 @@ pub struct LanguageConfig {
 
     #[serde(skip)]
     keys: Vec<(String, String)>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum RunCommandType {
+    Bool(bool),
+    StringVec(Vec<String>),
 }
 
 impl Config {
@@ -73,8 +80,32 @@ impl LanguageConfig {
     pub fn get_command_args(&self) -> Vec<String> {
         self.compile_command.iter().skip(1).cloned().collect()
     }
-    pub fn get_run_command(&self) -> Option<String> {
-        self.run_command.clone()
+    pub fn explicit_no_run(&self) -> bool {
+        match self.run_command.clone() {
+            Some(command_type) => match command_type {
+                RunCommandType::Bool(val) => !val,
+                _ => false,
+            }
+            _ => false,
+        }
+    }
+    pub fn get_run_command(&self, file: String) -> Option<(String, Vec<String>)> {
+        if let Some(command_type) = self.run_command.clone() {
+            return match command_type {
+                RunCommandType::Bool(b) => {
+                    if b {
+                        Some((file, Vec::with_capacity(0)))
+                    } else {
+                        None
+                    }
+                }
+                RunCommandType::StringVec(command) => Some((
+                    command[0].clone(),
+                    command.iter().take(1).cloned().collect(),
+                )),
+            };
+        }
+        None
     }
     pub fn get_prefix(&self) -> Option<String> {
         self.prefix.clone()
@@ -84,22 +115,6 @@ impl LanguageConfig {
     }
     pub fn get_extension(&self) -> Option<String> {
         self.extension.clone()
-    }
-    pub fn add_keys(&mut self, keys: Vec<(String, String)>) {
-        for key in keys.iter() {
-            self.keys.push(key.clone());
-        }
-
-        self.resolve_command();
-    }
-    fn resolve_command(&mut self) {
-        for command in self.compile_command.iter_mut() {
-            for (key, value) in self.keys.iter() {
-                if command.contains(key) {
-                    *command = command.replace(key, value);
-                }
-            }
-        }
     }
     pub fn to_string_from_input(&self, input: Vec<String>) -> String {
         let mut str = String::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,9 +30,6 @@ pub struct LanguageConfig {
 
     #[serde(skip)]
     template_end: usize,
-
-    #[serde(skip)]
-    keys: Vec<(String, String)>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct LanguageConfig {
     prefix: Option<String>,
     extension: Option<String>,
 
+    #[serde(rename = "run")]
     run_command: Option<RunCommandType>,
 
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct LanguageConfig {
     prefix: Option<String>,
     extension: Option<String>,
 
+    run_command: Option<String>,
+
     #[serde(default)]
     redir_input: bool,
 
@@ -70,6 +72,9 @@ impl LanguageConfig {
     }
     pub fn get_command_args(&self) -> Vec<String> {
         self.compile_command.iter().skip(1).cloned().collect()
+    }
+    pub fn get_run_command(&self) -> Option<String> {
+        self.run_command.clone()
     }
     pub fn get_prefix(&self) -> Option<String> {
         self.prefix.clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,10 @@ fn main() {
 
             output.output(input_opt, raw, prefix_opt);
         } else {
-            exit("Could not write tmp file!", 1);
+            exit(
+                &format!("An error occured while running!: \n{}", result.unwrap_err()),
+                1,
+            );
         }
     } else {
         exit(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod collect;
 mod config;
 mod templates;
 mod utils;
+mod variables;
 
 use crate::collect::QuickMDOutput;
 use crate::templates::Template;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -51,7 +51,7 @@ impl<'lang> Template<'lang> {
         str
     }
 
-    pub fn get_run_command(&self) -> Option<String> {
-        self.conf.get_run_command()
+    pub fn get_run_command(&self, file: String) -> Option<(String, Vec<String>)> {
+        self.conf.get_run_command(file)
     }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -12,7 +12,11 @@ pub struct Template<'lang> {
 
 impl<'lang> Template<'lang> {
     pub fn new(lang: &'lang str, conf: &'lang LanguageConfig, input: Vec<String>) -> Self {
-        Template { conf, input, file_ext: lang.to_string() }
+        Template {
+            conf,
+            input,
+            file_ext: lang.to_string(),
+        }
     }
 
     pub fn to_file_path(&self, path: PathBuf) -> std::io::Result<()> {
@@ -45,5 +49,9 @@ impl<'lang> Template<'lang> {
             str.push('\n');
         }
         str
+    }
+
+    pub fn get_run_command(&self) -> Option<String> {
+        self.conf.get_run_command()
     }
 }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -1,0 +1,46 @@
+use std::{borrow::Borrow, collections::HashMap, hash::Hash};
+
+pub struct VariableParser<Key, Value> {
+    variables: HashMap<Key, (Value, bool)>,
+}
+
+impl<'var, Value> VariableParser<&'var str, Value>
+where
+    Value: Copy + ToString,
+{
+    pub fn new(variables: Vec<(&'var str, Value)>) -> Self {
+        let mut hash: HashMap<&str, (Value, bool)> = HashMap::with_capacity(variables.len());
+
+        for (key, value) in variables.iter() {
+            let tuple = (*value, false);
+            hash.insert(*key, tuple);
+        }
+
+        Self { variables: hash }
+    }
+
+    pub fn parse_string_vec(&self, vec: &mut Vec<String>) {
+        for item in vec.iter_mut() {
+            if let Some(val) = self.variables.get(item.as_str()) {
+                *item = val.0.to_string()
+            }
+        }
+    }
+
+    pub fn parse_with_tracker(&mut self, vec: &mut Vec<String>) {
+        for item in vec.iter_mut() {
+            if let Some(val) = self.variables.get_mut(item.as_str()) {
+                *item = val.0.to_string();
+                val.1 = true;
+            }
+        }
+    }
+
+    pub fn had_used_var(&self, key: &'var str) -> bool {
+        if let Some((_, usued)) = self.variables.get(key) {
+            return *usued;
+        }
+
+        false
+    }
+}


### PR DESCRIPTION
This change allows for running commands for languages/systems that do not support running a file. 
For example, `python` requires a *shebang* at the top of the file to allow for *'running'* the file.

This change would allow for these languages to be used with templates.

## Example
```toml
[langs.py]
run_command = ["python", "{{IN}}"]
template = """
import matplotlib.plt as plt

<<< TEMPLATE START
<<< TEMPLATE END

print("Done!")
"""
```

## Blocking
- [x] Variables should be supported and parsed
- [x] Running commands after 'compiling' should be optional
- [ ] New Docs page for config option