### PR TITLE
refactor(cli)!: Use subcommands instead of global commands

### DIFF
--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -1,92 +1,40 @@
 # Using the CLI
 `QuickerMD` offers a simple CLI for using the program.
 
-## Arguments
+At any time, you can use the `--help` flag to discover any options available for any subcommand.
 
-| Argument | Required | Default | Description |
-|:--:|:--:|:--:|:--:|
-| `--lang`, `-l` | Yes | N/A | The language to run, from your config |
-| `input` | No[^1] | N/A | The input to be run |
-| `--show-input`, `-s` | No | False | Whether to show the original input as output|
-| `--raw`, `-r` | No | False | Whether to show the output *as-is* |
-| `--no-prefix`, `-n` | No | False | Disables the `prefix` feature in config |
+## Basic Usage
+### Running a Config
+To run a program, use the appropriately name command, `run`.
 
-
-[^1]: **Not** required if input is piped
-
-
-## Example Output
-### Default
 ```sh
-quicker_md --lang py 'print("Hello, python!")'
+quicker_md run --help
+quicker_md run py "print('Hello, this is cool!')"
+
+# The basic format is
+# quicker_md run <lang> <input>
 ```
 
-Output:
-```txt
-# Output:
-# Hello, python!
-```
-### Show Input
+You can also pipe commands!
+
 ```sh
-quicker_md --show-input --lang c 'printf("Is this a JS skill issue?: %s", 0.1 + 0.2 == 0.3 ? "Only JS sucks" : "All languages suck");'
+echo "print('My cool script that echos!')" | quicker_md run py
 ```
 
-Output:
-```c
-// Input:
-printf("Is this a JS skill issue?: %s", 0.1 + 0.2 == 0.3 ? "Only JS sucks" : "All languages suck");
+A useful case for this is using input from files!
 
-// Output:
-// Is this a JS skill issue?: All languages suck
-```
-### With Error
+!!! WARNING
+    Make **sure** that **you** are aware of the contents of the file before using
+
+
+### Getting Your Template
+To get your template, you can use the `dump-template` command
+
 ```sh
-quicker_md --show-input --lang c 'int x = 5; printf("%d\n", x)'
-```
+quicker_md dump-template --help
 
-Output:
-```c
-// Input:
-int x = 5; printf("%d\n", x)
+quicker_md dump-template py
 
-// Error:
-// C:\Users\USER\AppData\Local\Temp\.tmp6ZlN94\tmp.c: In function 'main':
-// C:\Users\USER\AppData\Local\Temp\.tmp6ZlN94\tmp.c:6:29: error: expected ';' before '}' token
-//     6 | int x = 5; printf("%d\n", x)
-//       |                             ^
-//       |                             ;
-//     7 | }
-//       | ~
-```
-
-### Raw
-```sh
-quicker_md --lang js --raw 'console.log(("hello").split("").reverse().join(""))'
-```
-
-Output:
-```txt
-// olleh
-```
-
-#### Raw + No-Prefix
-```sh
-quicker_md --no-prefix --lang js --raw 'console.log(("hello").split("").reverse().join(""))'
-```
-
-Output:
-```txt
-olleh
-```
-
-#### Raw + Show-Input
-```sh
-quicker_md --show-input --no-prefix --lang js --raw 'console.log(("hello").split("").reverse().join(""))'
-```
-
-Output:
-```text
-console.log(("hello").split("").reverse().join(""))
-
-olleh
+# The basic format is
+# quicker_md dump-template <lang>
 ```

--- a/docs/config/compiled-vs-interpreted.md
+++ b/docs/config/compiled-vs-interpreted.md
@@ -14,7 +14,7 @@ The `template` field holds a multi-line string that will be used to create a def
 If we run the following in the terminal:
 
 ```sh
-quicker_md --lang c 'printf("Hello, from QuickerMD");' --show-input
+quicker_md run c 'printf("Hello, from QuickerMD");' --show-input
 ```
 
 The created temporary file will look:
@@ -41,7 +41,7 @@ The `redir_input` is set to true. This tells `QuickerMD` that the input passed t
 If we run the following in the terminal:
 
 ```sh
-quicker_md --lang py 'print("Hello, from QuickerMD")'
+quicker_md run py 'print("Hello, from QuickerMD")'
 ```
 
 We are essentially running the following:

--- a/docs/config/example-config.md
+++ b/docs/config/example-config.md
@@ -49,7 +49,7 @@ pub fn main() {
 
 Try it with the following commands!
 ```sh
-quicker_md --show-input --lang js "console.log('Hello, from QuickerMD!')"
+quicker_md run js "console.log('Hello, from QuickerMD!')" --show-input
 ```
 
 ## Understanding Configuration

--- a/docs/config/file-extensions.md
+++ b/docs/config/file-extensions.md
@@ -16,7 +16,7 @@ pub fn main() {
 
 Running the command:
 ```sh
-quicker_md --lang rust "println!('Hello, world!');"
+quicker_md run rust "println!('Hello, world!');"
 ```
 
 Would produce the temporary file `out.rust`. While this *may* run, it is **not recommended** to use incorrect file types, as this may through warnings to the compiler.

--- a/docs/config/prefix.md
+++ b/docs/config/prefix.md
@@ -14,7 +14,7 @@ prefix = "// "
 ```
 
 ```sh
-echo 'console.log("What will this output")' | quicker_md --lang js --show-input
+echo 'console.log("What will this output")' | quicker_md run js --show-input
 ```
 
 Will output:

--- a/examples/run.ps1
+++ b/examples/run.ps1
@@ -9,4 +9,4 @@ if ($extension -like "py") {
     $extension = "python"
 }
 
-cat $path | quicker_md --lang $extension --show-input
+cat $path | quicker_md run $extension --show-input

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,15 +1,36 @@
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use std::io::{self, BufRead, IsTerminal};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    /// Language to use config from
-    #[arg(short, long)]
+    #[command(subcommand)]
+    pub actions: QuickerActions,
+}
+
+#[derive(Subcommand)]
+pub enum QuickerActions {
+    /// Dumps the template
+    DumpTemplate(DumpArgs),
+
+    /// Runs the template + input
+    Run(RunArgs),
+}
+
+#[derive(Args)]
+pub struct DumpArgs {
+    /// The language to dump its template
     pub lang: String,
 
-    /// Input to be passed in to the command
-    #[arg(value_name = "INPUT")]
+    /// Whether to remove the template lines
+    // TODO: Refactor template to add the ability to trim those lines
+    #[arg(short, long, default_value_t = false)]
+    pub remove_template_lines: bool,
+}
+
+#[derive(Args)]
+pub struct RunArgs {
+    pub lang: String,
     pub input: Option<String>,
 
     /// Show the input that was used to run
@@ -23,6 +44,7 @@ pub struct Cli {
     /// Don't show the prefix
     #[arg(short, long, default_value_t = false)]
     pub no_prefix: bool,
+
 }
 
 pub fn is_interactive() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,12 @@ pub enum RunCommandType {
     StringVec(Vec<String>),
 }
 
+pub enum OutputFormatType {
+    /// The Output is formatted by sorting
+    Sorted,
+    Grouped,
+}
+
 impl Config {
     pub fn from_config() -> Self {
         let path = ProjectDirs::from("", "", "QuickMD")
@@ -83,7 +89,7 @@ impl LanguageConfig {
             Some(command_type) => match command_type {
                 RunCommandType::Bool(val) => !val,
                 _ => false,
-            }
+            },
             _ => false,
         }
     }
@@ -113,6 +119,9 @@ impl LanguageConfig {
     }
     pub fn get_extension(&self) -> Option<String> {
         self.extension.clone()
+    }
+    pub fn get_template(&self) -> Option<String> {
+        self.template.clone()
     }
     pub fn to_string_from_input(&self, input: Vec<String>) -> String {
         let mut str = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn get_lang_conf_or_exit<'lang>(
     if let Some(lang_conf) = config.get_lang_conf(lang) {
         lang_conf
     } else {
-        exit(&format!("Template does not exist for '{}'", lang), 1);
+        exit(&format!("Language Config does not exist for '{}'", lang), 1);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,73 +1,79 @@
 use clap::Parser;
 use config::Config;
 
+mod cli;
 mod collect;
 mod config;
 mod templates;
 mod utils;
 mod variables;
-mod cli;
 
 use crate::collect::QuickMDOutput;
 use crate::templates::Template;
 
-fn main() {
-    let cli = cli::Cli::parse();
+fn exit(message: &str, code: i32) -> ! {
+    eprintln!("{}", message);
+    std::process::exit(code);
+}
 
-    let lang = cli.lang;
-    let raw = cli.raw;
-    let show_input = cli.show_input;
+fn dump_template(config: &Config, args: &cli::DumpArgs) {
+    if let Some(lang_conf) = config.get_lang_conf(&args.lang) {
+        let template = if let Some(temp) = lang_conf.get_template() {
+            temp
+        } else {
+            exit(&format!("Template does not exist for '{}'", args.lang), 1)
+        };
+
+        println!("{}", template);
+    } else {
+        exit(&format!("No Language Config for '{}'", args.lang), 1)
+    }
+}
+
+fn run_input(config: &Config, args: &cli::RunArgs) {
+    let lang_conf = if let Some(conf) = config.get_lang_conf(&args.lang) {
+        conf
+    } else {
+        exit(&format!("No Language Config for '{}'", args.lang), 1)
+    };
 
     let input_vec: Vec<String>;
 
     if cli::is_interactive() {
-        if let Some(input) = cli.input {
+        if let Some(input) = args.input.clone() {
             input_vec = input.lines().map(|s| s.to_string()).collect();
         } else {
-            exit("No input found. Please provide an input!", 1);
+            exit(&format!("No Input detected'{}'", args.lang), 1)
         }
     } else {
         input_vec = cli::collect_stdin();
     }
 
-    let config = Config::from_config();
+    let template = Template::new(&args.lang, lang_conf, input_vec.clone());
+    let output = QuickMDOutput::start(&template).map_err(|e| {
+        exit(&format!("There was an error running the program\n{}", e.to_string()), 1);
+    }).unwrap();
 
-    if let Some(lang_conf) = config.get_lang_conf(&lang) {
-        let template = Template::new(&lang, lang_conf, input_vec.clone());
-        let result = QuickMDOutput::start(&template);
-        if let Ok(output) = result {
-            let prefix_opt: Option<String>;
-
-            if cli.no_prefix {
-                prefix_opt = None;
-            } else {
-                prefix_opt = lang_conf.get_prefix();
-            }
-
-            let input_opt;
-
-            if show_input {
-                input_opt = Some(input_vec);
-            } else {
-                input_opt = None;
-            }
-
-            output.output(input_opt, raw, prefix_opt);
-        } else {
-            exit(
-                &format!("An error occured while running!: \n{}", result.unwrap_err()),
-                1,
-            );
-        }
+    let prefix_opt = if args.no_prefix {
+        None
     } else {
-        exit(
-            &format!("Language {} does not exist in your config!", lang),
-            1,
-        );
-    }
+        lang_conf.get_prefix()
+    };
+    let input_opt = if args.show_input {
+        Some(input_vec)
+    } else {
+        None
+    };
+
+    output.output(input_opt, args.raw, prefix_opt);
 }
 
-fn exit(message: &str, code: i32) -> ! {
-    eprintln!("{}", message);
-    std::process::exit(code);
+fn main() {
+    let cli = cli::Cli::parse();
+
+    let config = Config::from_config();
+    match cli.actions {
+        cli::QuickerActions::DumpTemplate(args) => dump_template(&config, &args),
+        cli::QuickerActions::Run(args) => run_input(&config, &args),
+    }
 }


### PR DESCRIPTION
BREAKING CHANGE: This change makes it easier to add new subcommands to the CLI. By using subcommands, it also improves discoverability of features, since the user has no need to know the possible options for commands that are not effective for their aimed goal.

## TODO:
- [x] Document all breaking changes
- [ ] ~~Improve error handling~~ This is better left for a different PR